### PR TITLE
Allow stale SQL objects to be closed

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,9 +36,9 @@ pluginManagement {
 
         id("com.github.spotbugs") version "5.0.+"
         id("com.diffplug.spotless") version "6.11.+"
-        id("com.github.vlsi.gradle-extensions") version "1.84"
-        id("com.github.vlsi.stage-vote-release") version "1.84"
-        id("com.github.vlsi.ide") version "1.84"
+        id("com.github.vlsi.gradle-extensions") version "1.+"
+        id("com.github.vlsi.stage-vote-release") version "1.+"
+        id("com.github.vlsi.ide") version "1.+"
         id("me.champeau.jmh") version "0.+"
         id("org.checkerframework") version "0.+"
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,9 +36,9 @@ pluginManagement {
 
         id("com.github.spotbugs") version "5.0.+"
         id("com.diffplug.spotless") version "6.11.+"
-        id("com.github.vlsi.gradle-extensions") version "1.+"
-        id("com.github.vlsi.stage-vote-release") version "1.+"
-        id("com.github.vlsi.ide") version "1.+"
+        id("com.github.vlsi.gradle-extensions") version "1.84"
+        id("com.github.vlsi.stage-vote-release") version "1.84"
+        id("com.github.vlsi.ide") version "1.84"
         id("me.champeau.jmh") version "0.+"
         id("org.checkerframework") version "0.+"
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/AwsWrapperDataSource.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/AwsWrapperDataSource.java
@@ -105,7 +105,7 @@ public class AwsWrapperDataSource implements DataSource, Referenceable, Serializ
         if (!StringUtils.isNullOrEmpty(this.jdbcUrl)) {
           parsePropertiesFromUrl(this.jdbcUrl, props);
         } else {
-          parsePropertiesFromUrl(this.urlPropertyName, props);
+          parsePropertiesFromUrl(props.getProperty(this.urlPropertyName), props);
         }
         setJdbcUrlOrUrlProperty(props);
         setDatabasePropertyFromUrl(props);

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -69,7 +69,7 @@ public class SqlMethodAnalyzer {
 
   public boolean doesCloseTransaction(final String methodName, final Object[] args) {
     if (methodName.equals("Connection.commit") || methodName.equals("Connection.rollback")
-        || isMethodClosingSqlObject(methodName)) {
+        || methodName.equals("Connection.close")) {
       return true;
     }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class ConnectionMethodAnalyzer {
+public class SqlMethodAnalyzer {
 
   public boolean doesOpenTransaction(final Connection currentConn, final String methodName, final Object[] args) {
     if (!(methodName.contains("execute") && args != null && args.length >= 1)) {
@@ -68,7 +68,8 @@ public class ConnectionMethodAnalyzer {
   }
 
   public boolean doesCloseTransaction(final String methodName, final Object[] args) {
-    if (methodName.equals("Connection.commit") || methodName.equals("Connection.rollback")) {
+    if (methodName.equals("Connection.commit") || methodName.equals("Connection.rollback")
+        || isMethodClosingSqlObject(methodName)) {
       return true;
     }
 
@@ -153,5 +154,13 @@ public class ConnectionMethodAnalyzer {
     } else {
       return null;
     }
+  }
+
+  public boolean isMethodClosingSqlObject(String methodName) {
+    if (methodName.contains(".")) {
+      methodName = methodName.substring(methodName.indexOf(".") + 1);
+    }
+
+    return methodName.equals("close") || methodName.equals("abort");
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -157,10 +157,6 @@ public class SqlMethodAnalyzer {
   }
 
   public boolean isMethodClosingSqlObject(String methodName) {
-    if (methodName.contains(".")) {
-      methodName = methodName.substring(methodName.indexOf(".") + 1);
-    }
-
-    return methodName.equals("close") || methodName.equals("abort");
+    return methodName.endsWith(".close") || methodName.endsWith(".abort");
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -69,7 +69,7 @@ public class SqlMethodAnalyzer {
 
   public boolean doesCloseTransaction(final String methodName, final Object[] args) {
     if (methodName.equals("Connection.commit") || methodName.equals("Connection.rollback")
-        || methodName.equals("Connection.close")) {
+        || methodName.equals("Connection.close") || methodName.equals("Connection.abort")) {
       return true;
     }
 

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -181,14 +181,15 @@ ReadWriteSplittingPlugin.settingCurrentConnection=Setting the current connection
 ReadWriteSplittingPlugin.noWriterFound=No writer was found in the current host list.
 ReadWriteSplittingPlugin.noReadersFound=The plugin expected reader hosts in the host list, but none were found.
 ReadWriteSplittingPlugin.emptyHostList=Host list is empty.
-ReadWriteSplittingPlugin.exceptionWhileExecutingCommand=Detected an exception while executing a command.
-ReadWriteSplittingPlugin.failoverExceptionWhileExecutingCommand=Detected a failover exception while executing a command.
+ReadWriteSplittingPlugin.exceptionWhileExecutingCommand=Detected an exception while executing a command: ''{0}''
+ReadWriteSplittingPlugin.failoverExceptionWhileExecutingCommand=Detected a failover exception while executing a command: ''{0}''
 ReadWriteSplittingPlugin.unsupportedDriverProtocol=Driver protocol ''{0}'' is not supported.
 ReadWriteSplittingPlugin.errorUpdatingHostSpecRole=An error occurred while trying to update the initial host spec role.
 ReadWriteSplittingPlugin.driverWillNotSwitchToNewReader=There is only one reader instance; the driver will not switch to a new reader.
 ReadWriteSplittingPlugin.successfullyConnectedToReader=Successfully connected to a new reader host: ''{0}''
 ReadWriteSplittingPlugin.failedToConnectToReader=Failed to connect to reader host: ''{0}''
 ReadWriteSplittingPlugin.transactionBoundaryDetectedSwitchingToNewReader=Transaction boundary detected - switching to a new reader instance.
+ReadWriteSplittingPlugin.executingAgainstOldConnection=Executing method against old connection: ''{0}''
 
 # Wrapper Utils
 WrapperUtils.noWrapperClassExists=No wrapper class exists for ''{0}''.

--- a/wrapper/src/test/java/integration/container/aurora/mysql/mysqldriver/AuroraMysqlReadWriteSplittingTest.java
+++ b/wrapper/src/test/java/integration/container/aurora/mysql/mysqldriver/AuroraMysqlReadWriteSplittingTest.java
@@ -680,6 +680,36 @@ public class AuroraMysqlReadWriteSplittingTest extends MysqlAuroraMysqlBaseTest 
     }
   }
 
+  @ParameterizedTest(name = "test_executeWithOldConnection")
+  @MethodSource("testParameters")
+  public void test_executeWithOldConnection(final Properties props) throws SQLException {
+    final String writerId = instanceIDs[0];
+    ReadWriteSplittingPlugin.LOAD_BALANCE_READ_ONLY_TRAFFIC.set(props, "true");
+    try (final Connection conn = connectToInstance(MYSQL_CLUSTER_URL, AURORA_MYSQL_PORT, props)) {
+      final String writerConnectionId = queryInstanceId(conn);
+      assertEquals(writerId, writerConnectionId);
+      assertTrue(isDBInstanceWriter(writerConnectionId));
+
+      final Statement oldStmt = conn.createStatement();
+      final ResultSet oldRs = oldStmt.executeQuery("SELECT 1");
+      conn.setReadOnly(true); // Connection is switched internally
+      conn.setAutoCommit(false);
+
+      assertThrows(SQLException.class, () -> oldStmt.execute("SELECT 1"));
+      assertThrows(SQLException.class, () -> oldRs.getInt(1));
+
+      final String readerId = queryInstanceId(conn);
+      assertNotEquals(writerId, readerId);
+      assertTrue(isDBInstanceReader(readerId));
+
+      assertDoesNotThrow(oldStmt::close);
+      assertDoesNotThrow(oldRs::close);
+
+      final String sameReaderId = queryInstanceId(conn);
+      assertEquals(readerId, sameReaderId);
+    }
+  }
+
   @Test
   public void test_failoverToNewWriter_setReadOnlyTrueFalse() throws SQLException, InterruptedException, IOException {
     final String initialWriterId = instanceIDs[0];

--- a/wrapper/src/test/java/integration/container/aurora/postgres/AuroraPostgresReadWriteSplittingTest.java
+++ b/wrapper/src/test/java/integration/container/aurora/postgres/AuroraPostgresReadWriteSplittingTest.java
@@ -640,6 +640,36 @@ public class AuroraPostgresReadWriteSplittingTest extends AuroraPostgresBaseTest
     }
   }
 
+  @ParameterizedTest(name = "test_executeWithOldConnection")
+  @MethodSource("testParameters")
+  public void test_executeWithOldConnection(final Properties props) throws SQLException {
+    final String writerId = instanceIDs[0];
+    ReadWriteSplittingPlugin.LOAD_BALANCE_READ_ONLY_TRAFFIC.set(props, "true");
+    try (final Connection conn = connectToInstance(POSTGRES_CLUSTER_URL, AURORA_POSTGRES_PORT, props)) {
+      final String writerConnectionId = queryInstanceId(conn);
+      assertEquals(writerId, writerConnectionId);
+      assertTrue(isDBInstanceWriter(writerConnectionId));
+
+      final Statement oldStmt = conn.createStatement();
+      final ResultSet oldRs = oldStmt.executeQuery("SELECT 1");
+      conn.setReadOnly(true); // Connection is switched internally
+      conn.setAutoCommit(false);
+
+      assertThrows(SQLException.class, () -> oldStmt.execute("SELECT 1"));
+      assertThrows(SQLException.class, () -> oldRs.getInt(1));
+
+      final String readerId = queryInstanceId(conn);
+      assertNotEquals(writerId, readerId);
+      assertTrue(isDBInstanceReader(readerId));
+
+      assertDoesNotThrow(oldStmt::close);
+      assertDoesNotThrow(oldRs::close);
+
+      final String sameReaderId = queryInstanceId(conn);
+      assertEquals(readerId, sameReaderId);
+    }
+  }
+
   @Test
   public void test_failoverToNewWriter_setReadOnlyTrueFalse() throws SQLException, InterruptedException, IOException {
     final String initialWriterId = instanceIDs[0];

--- a/wrapper/src/test/java/software/amazon/jdbc/ConnectionPluginManagerTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/ConnectionPluginManagerTests.java
@@ -439,12 +439,12 @@ public class ConnectionPluginManagerTests {
         () -> target.execute(String.class, Exception.class, mockOldResultSet, "testJdbcCall_A", () -> "result", null));
 
     assertDoesNotThrow(
-        () -> target.execute(Void.class, SQLException.class, mockOldConnection, "close", mockSqlFunction, null));
+        () -> target.execute(Void.class, SQLException.class, mockOldConnection, "Connection.close", mockSqlFunction, null));
     assertDoesNotThrow(
-        () -> target.execute(Void.class, SQLException.class, mockOldConnection, "abort", mockSqlFunction, null));
+        () -> target.execute(Void.class, SQLException.class, mockOldConnection, "Connection.abort", mockSqlFunction, null));
     assertDoesNotThrow(
-        () -> target.execute(Void.class, SQLException.class, mockOldStatement, "close", mockSqlFunction, null));
+        () -> target.execute(Void.class, SQLException.class, mockOldStatement, "Statement.close", mockSqlFunction, null));
     assertDoesNotThrow(
-        () -> target.execute(Void.class, SQLException.class, mockOldResultSet, "close", mockSqlFunction, null));
+        () -> target.execute(Void.class, SQLException.class, mockOldResultSet, "ResultSet.close", mockSqlFunction, null));
   }
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/ConnectionPluginManagerTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/ConnectionPluginManagerTests.java
@@ -16,6 +16,7 @@
 
 package software.amazon.jdbc;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
@@ -30,8 +31,12 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import software.amazon.jdbc.mock.TestPluginOne;
 import software.amazon.jdbc.mock.TestPluginThree;
 import software.amazon.jdbc.mock.TestPluginThrowException;
@@ -40,28 +45,42 @@ import software.amazon.jdbc.wrapper.ConnectionWrapper;
 
 public class ConnectionPluginManagerTests {
 
+  @Mock JdbcCallable<Void, SQLException> mockSqlFunction;
+
+  private AutoCloseable closeable;
+
+  @AfterEach
+  void cleanUp() throws Exception {
+    closeable.close();
+  }
+
+  @BeforeEach
+  void init() {
+    closeable = MockitoAnnotations.openMocks(this);
+  }
+
   @Test
   public void testExecuteJdbcCallA() throws Exception {
 
-    ArrayList<String> calls = new ArrayList<>();
+    final ArrayList<String> calls = new ArrayList<>();
 
-    ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
+    final ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
     testPlugins.add(new TestPluginOne(calls));
     testPlugins.add(new TestPluginTwo(calls));
     testPlugins.add(new TestPluginThree(calls));
 
-    Properties testProperties = new Properties();
+    final Properties testProperties = new Properties();
 
-    ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
+    final ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
 
-    ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
+    final ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
 
-    Object[] testArgs = new Object[] {10, "arg2", 3.33};
+    final Object[] testArgs = new Object[] {10, "arg2", 3.33};
 
-    ConnectionPluginManager target =
+    final ConnectionPluginManager target =
         new ConnectionPluginManager(mockConnectionProvider, testProperties, testPlugins, mockConnectionWrapper);
 
-    Object result =
+    final Object result =
         target.execute(
             String.class,
             Exception.class,
@@ -88,25 +107,25 @@ public class ConnectionPluginManagerTests {
   @Test
   public void testExecuteJdbcCallB() throws Exception {
 
-    ArrayList<String> calls = new ArrayList<>();
+    final ArrayList<String> calls = new ArrayList<>();
 
-    ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
+    final ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
     testPlugins.add(new TestPluginOne(calls));
     testPlugins.add(new TestPluginTwo(calls));
     testPlugins.add(new TestPluginThree(calls));
 
-    Properties testProperties = new Properties();
+    final Properties testProperties = new Properties();
 
-    ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
+    final ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
 
-    ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
+    final ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
 
-    Object[] testArgs = new Object[] {10, "arg2", 3.33};
+    final Object[] testArgs = new Object[] {10, "arg2", 3.33};
 
-    ConnectionPluginManager target =
+    final ConnectionPluginManager target =
         new ConnectionPluginManager(mockConnectionProvider, testProperties, testPlugins, mockConnectionWrapper);
 
-    Object result =
+    final Object result =
         target.execute(
             String.class,
             Exception.class,
@@ -131,25 +150,25 @@ public class ConnectionPluginManagerTests {
   @Test
   public void testExecuteJdbcCallC() throws Exception {
 
-    ArrayList<String> calls = new ArrayList<>();
+    final ArrayList<String> calls = new ArrayList<>();
 
-    ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
+    final ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
     testPlugins.add(new TestPluginOne(calls));
     testPlugins.add(new TestPluginTwo(calls));
     testPlugins.add(new TestPluginThree(calls));
 
-    Properties testProperties = new Properties();
+    final Properties testProperties = new Properties();
 
-    ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
+    final ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
 
-    ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
+    final ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
 
-    Object[] testArgs = new Object[] {10, "arg2", 3.33};
+    final Object[] testArgs = new Object[] {10, "arg2", 3.33};
 
-    ConnectionPluginManager target =
+    final ConnectionPluginManager target =
         new ConnectionPluginManager(mockConnectionProvider, testProperties, testPlugins, mockConnectionWrapper);
 
-    Object result =
+    final Object result =
         target.execute(
             String.class,
             Exception.class,
@@ -172,22 +191,22 @@ public class ConnectionPluginManagerTests {
   @Test
   public void testConnect() throws Exception {
 
-    Connection expectedConnection = mock(Connection.class);
+    final Connection expectedConnection = mock(Connection.class);
 
-    ArrayList<String> calls = new ArrayList<>();
+    final ArrayList<String> calls = new ArrayList<>();
 
-    ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
+    final ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
     testPlugins.add(new TestPluginOne(calls));
     testPlugins.add(new TestPluginTwo(calls));
     testPlugins.add(new TestPluginThree(calls, expectedConnection));
 
-    Properties testProperties = new Properties();
-    ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
-    ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
-    ConnectionPluginManager target =
+    final Properties testProperties = new Properties();
+    final ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
+    final ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
+    final ConnectionPluginManager target =
         new ConnectionPluginManager(mockConnectionProvider, testProperties, testPlugins, mockConnectionWrapper);
 
-    Connection conn = target.connect("any", new HostSpec("anyHost"), testProperties, true);
+    final Connection conn = target.connect("any", new HostSpec("anyHost"), testProperties, true);
 
     assertEquals(expectedConnection, conn);
     assertEquals(4, calls.size());
@@ -200,18 +219,18 @@ public class ConnectionPluginManagerTests {
   @Test
   public void testConnectWithSQLExceptionBefore() {
 
-    ArrayList<String> calls = new ArrayList<>();
+    final ArrayList<String> calls = new ArrayList<>();
 
-    ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
+    final ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
     testPlugins.add(new TestPluginOne(calls));
     testPlugins.add(new TestPluginTwo(calls));
     testPlugins.add(new TestPluginThrowException(calls, SQLException.class, true));
     testPlugins.add(new TestPluginThree(calls, mock(Connection.class)));
 
-    Properties testProperties = new Properties();
-    ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
-    ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
-    ConnectionPluginManager target =
+    final Properties testProperties = new Properties();
+    final ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
+    final ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
+    final ConnectionPluginManager target =
         new ConnectionPluginManager(mockConnectionProvider, testProperties, testPlugins, mockConnectionWrapper);
 
     assertThrows(
@@ -226,18 +245,18 @@ public class ConnectionPluginManagerTests {
   @Test
   public void testConnectWithSQLExceptionAfter() {
 
-    ArrayList<String> calls = new ArrayList<>();
+    final ArrayList<String> calls = new ArrayList<>();
 
-    ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
+    final ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
     testPlugins.add(new TestPluginOne(calls));
     testPlugins.add(new TestPluginTwo(calls));
     testPlugins.add(new TestPluginThrowException(calls, SQLException.class, false));
     testPlugins.add(new TestPluginThree(calls, mock(Connection.class)));
 
-    Properties testProperties = new Properties();
-    ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
-    ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
-    ConnectionPluginManager target =
+    final Properties testProperties = new Properties();
+    final ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
+    final ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
+    final ConnectionPluginManager target =
         new ConnectionPluginManager(mockConnectionProvider, testProperties, testPlugins, mockConnectionWrapper);
 
     assertThrows(
@@ -255,21 +274,21 @@ public class ConnectionPluginManagerTests {
   @Test
   public void testConnectWithUnexpectedExceptionBefore() {
 
-    ArrayList<String> calls = new ArrayList<>();
+    final ArrayList<String> calls = new ArrayList<>();
 
-    ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
+    final ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
     testPlugins.add(new TestPluginOne(calls));
     testPlugins.add(new TestPluginTwo(calls));
     testPlugins.add(new TestPluginThrowException(calls, IllegalArgumentException.class, true));
     testPlugins.add(new TestPluginThree(calls, mock(Connection.class)));
 
-    Properties testProperties = new Properties();
-    ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
-    ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
-    ConnectionPluginManager target =
+    final Properties testProperties = new Properties();
+    final ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
+    final ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
+    final ConnectionPluginManager target =
         new ConnectionPluginManager(mockConnectionProvider, testProperties, testPlugins, mockConnectionWrapper);
 
-    Exception ex =
+    final Exception ex =
         assertThrows(
             IllegalArgumentException.class,
             () -> target.connect("any", new HostSpec("anyHost"), testProperties, true));
@@ -282,21 +301,21 @@ public class ConnectionPluginManagerTests {
   @Test
   public void testConnectWithUnexpectedExceptionAfter() {
 
-    ArrayList<String> calls = new ArrayList<>();
+    final ArrayList<String> calls = new ArrayList<>();
 
-    ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
+    final ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
     testPlugins.add(new TestPluginOne(calls));
     testPlugins.add(new TestPluginTwo(calls));
     testPlugins.add(new TestPluginThrowException(calls, IllegalArgumentException.class, false));
     testPlugins.add(new TestPluginThree(calls, mock(Connection.class)));
 
-    Properties testProperties = new Properties();
-    ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
-    ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
-    ConnectionPluginManager target =
+    final Properties testProperties = new Properties();
+    final ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
+    final ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
+    final ConnectionPluginManager target =
         new ConnectionPluginManager(mockConnectionProvider, testProperties, testPlugins, mockConnectionWrapper);
 
-    Exception ex =
+    final Exception ex =
         assertThrows(
             IllegalArgumentException.class,
             () -> target.connect("any", new HostSpec("anyHost"), testProperties, true));
@@ -312,22 +331,22 @@ public class ConnectionPluginManagerTests {
   @Test
   public void testExecuteCachedJdbcCallA() throws Exception {
 
-    ArrayList<String> calls = new ArrayList<>();
+    final ArrayList<String> calls = new ArrayList<>();
 
-    ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
+    final ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
     testPlugins.add(new TestPluginOne(calls));
     testPlugins.add(new TestPluginTwo(calls));
     testPlugins.add(new TestPluginThree(calls));
 
-    Properties testProperties = new Properties();
+    final Properties testProperties = new Properties();
 
-    ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
+    final ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
 
-    ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
+    final ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
 
-    Object[] testArgs = new Object[] {10, "arg2", 3.33};
+    final Object[] testArgs = new Object[] {10, "arg2", 3.33};
 
-    ConnectionPluginManager target = Mockito.spy(
+    final ConnectionPluginManager target = Mockito.spy(
         new ConnectionPluginManager(mockConnectionProvider, testProperties, testPlugins, mockConnectionWrapper));
 
     Object result =
@@ -387,22 +406,28 @@ public class ConnectionPluginManagerTests {
 
   @Test
   public void testExecuteAgainstOldConnection() throws Exception {
-    ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
-    Properties testProperties = new Properties();
+    final ArrayList<String> calls = new ArrayList<>();
 
-    PluginService mockPluginService = mock(PluginService.class);
-    ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
-    ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
-    Connection mockOldConnection = mock(Connection.class);
-    Connection mockCurrentConnection = mock(Connection.class);
-    Statement mockOldStatement = mock(Statement.class);
-    ResultSet mockOldResultSet = mock(ResultSet.class);
+    final ArrayList<ConnectionPlugin> testPlugins = new ArrayList<>();
+    testPlugins.add(new TestPluginOne(calls));
+    testPlugins.add(new TestPluginTwo(calls));
+    testPlugins.add(new TestPluginThree(calls));
+
+    final Properties testProperties = new Properties();
+
+    final PluginService mockPluginService = mock(PluginService.class);
+    final ConnectionProvider mockConnectionProvider = mock(ConnectionProvider.class);
+    final ConnectionWrapper mockConnectionWrapper = mock(ConnectionWrapper.class);
+    final Connection mockOldConnection = mock(Connection.class);
+    final Connection mockCurrentConnection = mock(Connection.class);
+    final Statement mockOldStatement = mock(Statement.class);
+    final ResultSet mockOldResultSet = mock(ResultSet.class);
 
     when(mockPluginService.getCurrentConnection()).thenReturn(mockCurrentConnection);
     when(mockOldStatement.getConnection()).thenReturn(mockOldConnection);
     when(mockOldResultSet.getStatement()).thenReturn(mockOldStatement);
 
-    ConnectionPluginManager target =
+    final ConnectionPluginManager target =
         new ConnectionPluginManager(mockConnectionProvider, testProperties, testPlugins, mockConnectionWrapper,
             mockPluginService);
 
@@ -412,6 +437,14 @@ public class ConnectionPluginManagerTests {
         () -> target.execute(String.class, Exception.class, mockOldStatement, "testJdbcCall_A", () -> "result", null));
     assertThrows(SQLException.class,
         () -> target.execute(String.class, Exception.class, mockOldResultSet, "testJdbcCall_A", () -> "result", null));
-  }
 
+    assertDoesNotThrow(
+        () -> target.execute(Void.class, SQLException.class, mockOldConnection, "close", mockSqlFunction, null));
+    assertDoesNotThrow(
+        () -> target.execute(Void.class, SQLException.class, mockOldConnection, "abort", mockSqlFunction, null));
+    assertDoesNotThrow(
+        () -> target.execute(Void.class, SQLException.class, mockOldStatement, "close", mockSqlFunction, null));
+    assertDoesNotThrow(
+        () -> target.execute(Void.class, SQLException.class, mockOldResultSet, "close", mockSqlFunction, null));
+  }
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/ConnectionPluginManagerTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/ConnectionPluginManagerTests.java
@@ -439,12 +439,16 @@ public class ConnectionPluginManagerTests {
         () -> target.execute(String.class, Exception.class, mockOldResultSet, "testJdbcCall_A", () -> "result", null));
 
     assertDoesNotThrow(
-        () -> target.execute(Void.class, SQLException.class, mockOldConnection, "Connection.close", mockSqlFunction, null));
+        () -> target.execute(Void.class, SQLException.class, mockOldConnection, "Connection.close", mockSqlFunction,
+            null));
     assertDoesNotThrow(
-        () -> target.execute(Void.class, SQLException.class, mockOldConnection, "Connection.abort", mockSqlFunction, null));
+        () -> target.execute(Void.class, SQLException.class, mockOldConnection, "Connection.abort", mockSqlFunction,
+            null));
     assertDoesNotThrow(
-        () -> target.execute(Void.class, SQLException.class, mockOldStatement, "Statement.close", mockSqlFunction, null));
+        () -> target.execute(Void.class, SQLException.class, mockOldStatement, "Statement.close", mockSqlFunction,
+            null));
     assertDoesNotThrow(
-        () -> target.execute(Void.class, SQLException.class, mockOldResultSet, "ResultSet.close", mockSqlFunction, null));
+        () -> target.execute(Void.class, SQLException.class, mockOldResultSet, "ResultSet.close", mockSqlFunction,
+            null));
   }
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
@@ -21,9 +21,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.AnyOf.anyOf;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,6 +36,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Properties;
@@ -83,11 +87,13 @@ public class ReadWriteSplittingPluginTest {
 
   @Mock private JdbcCallable<Connection, SQLException> mockConnectFunc;
   @Mock private JdbcCallable<ResultSet, SQLException> mockSqlFunction;
+  @Mock private JdbcCallable<Void, SQLException> mockVoidFunction;
   @Mock private PluginService mockPluginService;
   @Mock private HostListProviderService mockHostListProviderService;
   @Mock private Connection mockWriterConn;
   @Mock private Connection mockNewWriterConn;
   @Mock private Connection mockClosedWriterConn;
+  @Mock private Connection mockOldWriterConn;
   @Mock private Connection mockReaderConn1;
   @Mock private Connection mockReaderConn2;
   @Mock private Connection mockReaderConn3;
@@ -128,7 +134,7 @@ public class ReadWriteSplittingPluginTest {
     when(this.mockPluginService.getHosts()).thenReturn(singleReaderTopology);
     when(mockPluginService.getCurrentConnection()).thenReturn(mockWriterConn);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
@@ -158,7 +164,7 @@ public class ReadWriteSplittingPluginTest {
     when(mockPluginService.getCurrentConnection()).thenReturn(mockReaderConn1);
     when(mockPluginService.getCurrentHostSpec()).thenReturn(readerHostSpec1);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
@@ -178,7 +184,7 @@ public class ReadWriteSplittingPluginTest {
     when(mockPluginService.getCurrentConnection()).thenReturn(mockWriterConn);
     when(mockPluginService.getCurrentHostSpec()).thenReturn(writerHostSpec);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
@@ -198,7 +204,7 @@ public class ReadWriteSplittingPluginTest {
     when(this.mockPluginService.getHosts()).thenReturn(singleReaderTopology);
     when(mockPluginService.isInTransaction()).thenReturn(true);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
@@ -211,7 +217,7 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_true() throws SQLException {
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(mockPluginService, defaultProps);
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(mockPluginService, defaultProps);
     plugin.switchConnectionIfRequired(true);
 
     assertThat(plugin.getReaderConnection(), anyOf(is(mockReaderConn1), is(mockReaderConn2), is(mockReaderConn3)));
@@ -222,7 +228,7 @@ public class ReadWriteSplittingPluginTest {
     when(this.mockPluginService.getCurrentConnection()).thenReturn(mockReaderConn1);
     when(this.mockPluginService.getCurrentHostSpec()).thenReturn(readerHostSpec1);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
@@ -235,9 +241,9 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_true_oneHost() throws SQLException {
-    when(this.mockPluginService.getHosts()).thenReturn(Arrays.asList(writerHostSpec));
+    when(this.mockPluginService.getHosts()).thenReturn(Collections.singletonList(writerHostSpec));
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
@@ -252,10 +258,10 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testSetReadOnly_true_oneHost_writerClosed() throws SQLException {
-    when(this.mockPluginService.getHosts()).thenReturn(Arrays.asList(writerHostSpec));
+    when(this.mockPluginService.getHosts()).thenReturn(Collections.singletonList(writerHostSpec));
     when(this.mockPluginService.getCurrentConnection()).thenReturn(mockClosedWriterConn);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
@@ -276,7 +282,7 @@ public class ReadWriteSplittingPluginTest {
     when(mockPluginService.getCurrentConnection()).thenReturn(mockReaderConn1);
     when(mockPluginService.getCurrentHostSpec()).thenReturn(readerHostSpec1);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
@@ -294,7 +300,7 @@ public class ReadWriteSplittingPluginTest {
     when(this.mockPluginService.connect(eq(readerHostSpec2), eq(defaultProps))).thenThrow(SQLException.class);
     when(this.mockPluginService.connect(eq(readerHostSpec3), eq(defaultProps))).thenThrow(SQLException.class);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
@@ -313,7 +319,7 @@ public class ReadWriteSplittingPluginTest {
     when(mockPluginService.connect(eq(readerHostSpec3), eq(defaultProps))).thenThrow(SQLException.class);
     when(mockPluginService.getCurrentConnection()).thenReturn(mockClosedWriterConn);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
@@ -331,7 +337,7 @@ public class ReadWriteSplittingPluginTest {
     when(mockSqlFunction.call()).thenThrow(FailoverSuccessSQLException.class);
     when(mockPluginService.getCurrentConnection()).thenReturn(mockNewWriterConn);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
@@ -343,7 +349,7 @@ public class ReadWriteSplittingPluginTest {
         () -> plugin.execute(
             ResultSet.class,
             SQLException.class,
-            Statement.class,
+            mockStatement,
             "Statement.executeQuery",
             mockSqlFunction,
             new Object[] {
@@ -353,14 +359,14 @@ public class ReadWriteSplittingPluginTest {
 
   @Test
   public void testNotifyConnectionChange() {
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
         null,
         null);
 
-    OldConnectionSuggestedAction suggestion = plugin.notifyConnectionChanged(mockChanges);
+    final OldConnectionSuggestedAction suggestion = plugin.notifyConnectionChanged(mockChanges);
 
     assertEquals(mockWriterConn, plugin.getWriterConnection());
     assertEquals(OldConnectionSuggestedAction.NO_OPINION, suggestion);
@@ -371,9 +377,9 @@ public class ReadWriteSplittingPluginTest {
   public void testExecute_pickNewReader() throws SQLException {
     when(this.mockPluginService.getCurrentHostSpec()).thenReturn(readerHostSpec1);
 
-    Properties props = new Properties(defaultProps);
+    final Properties props = new Properties(defaultProps);
     ReadWriteSplittingPlugin.LOAD_BALANCE_READ_ONLY_TRAFFIC.set(props, "true");
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         props,
         mockHostListProviderService,
@@ -386,7 +392,7 @@ public class ReadWriteSplittingPluginTest {
     plugin.execute(
         ResultSet.class,
         SQLException.class,
-        Statement.class,
+        mockStatement,
         "Statement.executeQuery",
         mockSqlFunction,
         new Object[] {
@@ -396,15 +402,70 @@ public class ReadWriteSplittingPluginTest {
   }
 
   @Test
+  public void testExecute_closeAtTransactionBoundary() throws SQLException {
+    when(this.mockPluginService.getCurrentHostSpec()).thenReturn(readerHostSpec1);
+    when(this.mockPluginService.getCurrentConnection()).thenReturn(mockReaderConn1);
+    when(mockStatement.getConnection()).thenReturn(mockReaderConn1);
+
+    final Properties props = new Properties(defaultProps);
+    ReadWriteSplittingPlugin.LOAD_BALANCE_READ_ONLY_TRAFFIC.set(props, "true");
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+        mockPluginService,
+        props,
+        mockHostListProviderService,
+        null,
+        mockReaderConn1);
+
+    plugin.setExplicitlyReadOnly(true);
+    plugin.setIsTransactionBoundary(true);
+
+    plugin.execute(
+        Void.class,
+        SQLException.class,
+        mockStatement,
+        "Statement.close",
+        mockVoidFunction,
+        new Object[] {});
+
+    assertTrue(plugin.getIsTransactionBoundary());
+    verify(mockPluginService, never()).connect(any(), any());
+  }
+
+  @Test
+  public void testExecute_oldConnection() throws SQLException {
+    when(mockStatement.getConnection()).thenReturn(mockOldWriterConn);
+
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+        mockPluginService,
+        defaultProps,
+        mockHostListProviderService,
+        mockWriterConn,
+        null);
+    plugin.setIsTransactionBoundary(false);
+
+    plugin.execute(
+        Void.class,
+        SQLException.class,
+        mockStatement,
+        "Statement.close",
+        mockVoidFunction,
+        new Object[] {});
+
+    assertFalse(plugin.getIsTransactionBoundary());
+    verify(mockPluginService, never()).connect(any(), any());
+  }
+
+  @Test
   public void testConnectNonInitialConnection() throws SQLException {
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
         mockWriterConn,
         null);
 
-    Connection connection = plugin.connect(TEST_PROTOCOL, writerHostSpec, defaultProps, false, this.mockConnectFunc);
+    final Connection connection =
+        plugin.connect(TEST_PROTOCOL, writerHostSpec, defaultProps, false, this.mockConnectFunc);
 
     assertEquals(mockWriterConn, connection);
     verify(mockConnectFunc).call();
@@ -417,13 +478,13 @@ public class ReadWriteSplittingPluginTest {
     when(this.mockPluginService.getCurrentHostSpec()).thenReturn(readerHostSpecWithIncorrectRole);
     when(this.mockConnectFunc.call()).thenReturn(mockReaderConn1);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
         null,
         null);
-    Connection connection = plugin.connect(
+    final Connection connection = plugin.connect(
         TEST_PROTOCOL,
         instanceUrlHostSpec,
         defaultProps,
@@ -442,13 +503,14 @@ public class ReadWriteSplittingPluginTest {
     when(this.mockConnectFunc.call()).thenReturn(mockReaderConn1);
     when(mockResultSet.getString(any(String.class))).thenReturn("instance-1");
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
         null,
         null);
-    Connection connection = plugin.connect(TEST_PROTOCOL, ipUrlHostSpec, defaultProps, true, this.mockConnectFunc);
+    final Connection connection =
+        plugin.connect(TEST_PROTOCOL, ipUrlHostSpec, defaultProps, true, this.mockConnectFunc);
 
     assertEquals(mockReaderConn1, connection);
     verify(mockConnectFunc).call();
@@ -459,13 +521,14 @@ public class ReadWriteSplittingPluginTest {
   public void testConnectClusterUrl() throws SQLException {
     when(this.mockPluginService.getCurrentConnection()).thenReturn(null);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,
         null,
         null);
-    Connection connection = plugin.connect(TEST_PROTOCOL, clusterUrlHostSpec, defaultProps, true, this.mockConnectFunc);
+    final Connection connection =
+        plugin.connect(TEST_PROTOCOL, clusterUrlHostSpec, defaultProps, true, this.mockConnectFunc);
 
     assertEquals(mockWriterConn, connection);
     verify(mockConnectFunc).call();
@@ -476,7 +539,7 @@ public class ReadWriteSplittingPluginTest {
   public void testConnect_errorUpdatingHostSpec() {
     when(this.mockPluginService.getCurrentConnection()).thenReturn(null);
 
-    ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
+    final ReadWriteSplittingPlugin plugin = new ReadWriteSplittingPlugin(
         mockPluginService,
         defaultProps,
         mockHostListProviderService,

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
@@ -422,8 +422,8 @@ public class ReadWriteSplittingPluginTest {
     plugin.execute(
         Void.class,
         SQLException.class,
-        mockStatement,
-        "Statement.close",
+        mockReaderConn1,
+        "Connection.close",
         mockVoidFunction,
         new Object[] {});
 

--- a/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
@@ -30,12 +30,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-class ConnectionMethodAnalyzerTest {
+class SqlMethodAnalyzerTest {
 
   @Mock
   Connection conn;
 
-  private ConnectionMethodAnalyzer connectionMethodAnalyzer = new ConnectionMethodAnalyzer();
+  private SqlMethodAnalyzer sqlMethodAnalyzer = new SqlMethodAnalyzer();
   private AutoCloseable closeable;
 
   @BeforeEach
@@ -60,7 +60,7 @@ class ConnectionMethodAnalyzerTest {
     }
 
     when(conn.getAutoCommit()).thenReturn(autocommit);
-    final boolean actual = connectionMethodAnalyzer.doesOpenTransaction(conn, methodName, args);
+    final boolean actual = sqlMethodAnalyzer.doesOpenTransaction(conn, methodName, args);
     assertEquals(expected, actual);
   }
 
@@ -74,7 +74,7 @@ class ConnectionMethodAnalyzerTest {
       args = new Object[] {};
     }
 
-    final boolean actual = connectionMethodAnalyzer.doesCloseTransaction(methodName, args);
+    final boolean actual = sqlMethodAnalyzer.doesCloseTransaction(methodName, args);
     assertEquals(expected, actual);
   }
 
@@ -88,7 +88,7 @@ class ConnectionMethodAnalyzerTest {
       args = new Object[] {};
     }
 
-    final boolean actual = connectionMethodAnalyzer.isExecuteDml(methodName, args);
+    final boolean actual = sqlMethodAnalyzer.isExecuteDml(methodName, args);
     assertEquals(expected, actual);
   }
 
@@ -102,7 +102,7 @@ class ConnectionMethodAnalyzerTest {
       args = new Object[] {};
     }
 
-    final boolean actual = connectionMethodAnalyzer.isStatementSettingAutoCommit(methodName, args);
+    final boolean actual = sqlMethodAnalyzer.isStatementSettingAutoCommit(methodName, args);
     assertEquals(expected, actual);
   }
 
@@ -116,7 +116,7 @@ class ConnectionMethodAnalyzerTest {
       args = new Object[] {};
     }
 
-    final Boolean actual = connectionMethodAnalyzer.getAutoCommitValueFromSqlStatement(args);
+    final Boolean actual = sqlMethodAnalyzer.getAutoCommitValueFromSqlStatement(args);
     assertEquals(expected, actual);
   }
 
@@ -147,8 +147,12 @@ class ConnectionMethodAnalyzerTest {
         Arguments.of("Statement.executeUpdate", "end", true),
         Arguments.of("Statement.executeUpdate", "abort;", true),
         Arguments.of("Statement.execute", "select 1", false),
+        Arguments.of("Statement.close", null, true),
+        Arguments.of("Statement.isClosed", null, false),
         Arguments.of("Connection.commit", null, true),
-        Arguments.of("Connection.rollback", null, true)
+        Arguments.of("Connection.rollback", null, true),
+        Arguments.of("Connection.close", null, true),
+        Arguments.of("Connection.abort", null, true)
     );
   }
 

--- a/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
@@ -108,7 +108,7 @@ class SqlMethodAnalyzerTest {
 
   @ParameterizedTest
   @MethodSource("getAutoCommitQueries")
-  void testGetAutoCommit(final String sql, final boolean expected) {
+  void testGetAutoCommit(final String sql, final Boolean expected) {
     final Object[] args;
     if (sql != null) {
       args = new Object[] {sql};
@@ -116,7 +116,7 @@ class SqlMethodAnalyzerTest {
       args = new Object[] {};
     }
 
-    final boolean actual = sqlMethodAnalyzer.getAutoCommitValueFromSqlStatement(args);
+    final Boolean actual = sqlMethodAnalyzer.getAutoCommitValueFromSqlStatement(args);
     assertEquals(expected, actual);
   }
 

--- a/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
@@ -147,7 +147,7 @@ class SqlMethodAnalyzerTest {
         Arguments.of("Statement.executeUpdate", "end", true),
         Arguments.of("Statement.executeUpdate", "abort;", true),
         Arguments.of("Statement.execute", "select 1", false),
-        Arguments.of("Statement.close", null, true),
+        Arguments.of("Statement.close", null, false),
         Arguments.of("Statement.isClosed", null, false),
         Arguments.of("Connection.commit", null, true),
         Arguments.of("Connection.rollback", null, true),


### PR DESCRIPTION
- These changes fix a bug where stale SQL objects were blocked from being closed by a SQLException that was being thrown