### PR TITLE
test: allow users to override internal connection pool mapping

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/HikariPoolMapping.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HikariPoolMapping.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc;
+
+import java.util.Properties;
+
+@FunctionalInterface
+public interface HikariPoolMapping {
+  String getKey(HostSpec hostSpec, Properties originalProps);
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/HikariPooledConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HikariPooledConnectionProvider.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.cleanup.CanReleaseResources;
@@ -42,10 +44,41 @@ public abstract class HikariPooledConnectionProvider implements PooledConnection
   private static final RdsUtils rdsUtils = new RdsUtils();
   private static final Map<String, HikariDataSource> databasePools = new ConcurrentHashMap<>();
   private final HikariPoolConfigurator poolConfigurator;
+  private final HikariPoolMapping poolMapping;
+  private final Supplier<HikariDataSource> dataSourceSupplier;
   protected int retries = 10;
 
   public HikariPooledConnectionProvider(HikariPoolConfigurator hikariPoolConfigurator) {
-    poolConfigurator = hikariPoolConfigurator;
+    this(hikariPoolConfigurator, (hostSpec, properties) -> hostSpec.getUrl());
+  }
+
+  HikariPooledConnectionProvider(
+      HikariPoolConfigurator hikariPoolConfigurator,
+      Supplier<HikariDataSource> dataSourceSupplier) {
+    this(hikariPoolConfigurator, (hostSpec, properties) -> hostSpec.getUrl(), dataSourceSupplier);
+  }
+
+  /**
+   * {@link HikariPooledConnectionProvider} constructor.
+   *
+   * @param hikariPoolConfigurator A lambda that returns a {@link HikariConfig}
+   *                               object with specific Hikari configurations.
+   * @param mapping A lambda that returns a String that maps to a specific {@link HikariDataSource}
+   *                for the internal connection pool.
+   */
+  public HikariPooledConnectionProvider(
+      HikariPoolConfigurator hikariPoolConfigurator,
+      HikariPoolMapping mapping) {
+    this(hikariPoolConfigurator, mapping, null);
+  }
+
+  HikariPooledConnectionProvider(
+      HikariPoolConfigurator hikariPoolConfigurator,
+      HikariPoolMapping mapping,
+      Supplier<HikariDataSource> dataSourceSupplier) {
+    this.poolConfigurator = hikariPoolConfigurator;
+    this.poolMapping = mapping;
+    this.dataSourceSupplier = dataSourceSupplier;
   }
 
   @Override
@@ -73,7 +106,10 @@ public abstract class HikariPooledConnectionProvider implements PooledConnection
       @NonNull String protocol, @NonNull HostSpec hostSpec, @NonNull Properties props)
       throws SQLException {
     HikariDataSource ds = databasePools.computeIfAbsent(
-        hostSpec.getUrl(), url -> {
+        poolMapping.getKey(hostSpec, props), url -> {
+          if (this.dataSourceSupplier != null) {
+            return this.dataSourceSupplier.get();
+          }
           HikariConfig config = poolConfigurator.configurePool(hostSpec, props);
           setConnectionProperties(config, hostSpec, props);
           return new HikariDataSource(config);

--- a/wrapper/src/test/java/software/amazon/jdbc/HikariPooledConnectionProviderTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/HikariPooledConnectionProviderTest.java
@@ -18,7 +18,6 @@ package software.amazon.jdbc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -55,7 +54,6 @@ class HikariPooledConnectionProviderTest {
 
   @AfterEach
   void tearDown() throws Exception {
-    ConnectionProviderManager.releaseResources();
     closeable.close();
   }
 
@@ -74,6 +72,8 @@ class HikariPooledConnectionProviderTest {
       final Set<String> hosts = provider.getHosts();
       assertEquals(expected, hosts);
     }
+
+    provider.releaseResources();
   }
 
   @Test
@@ -92,6 +92,8 @@ class HikariPooledConnectionProviderTest {
       final Set<String> hosts = provider.getHosts();
       assertEquals(expected, hosts);
     }
+
+    provider.releaseResources();
   }
 
   class TestHikariPooledConnectionProvider extends HikariPooledConnectionProvider {

--- a/wrapper/src/test/java/software/amazon/jdbc/HikariPooledConnectionProviderTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/HikariPooledConnectionProviderTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class HikariPooledConnectionProviderTest {
+  @Mock Connection mockConnection;
+  @Mock HikariDataSource mockDataSource;
+  @Mock HikariConfig mockConfig;
+  @Mock HostSpec mockHostSpec;
+
+  private AutoCloseable closeable;
+  private static final Properties emptyProperties = new Properties();
+
+  @AfterEach
+  void cleanUp() throws Exception {
+    closeable.close();
+  }
+
+  @BeforeEach
+  void init() throws SQLException {
+    closeable = MockitoAnnotations.openMocks(this);
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.isValid(any(Integer.class))).thenReturn(true);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    ConnectionProviderManager.releaseResources();
+    closeable.close();
+  }
+
+  @Test
+  void testConnectWithDefaultMapping() throws SQLException {
+    when(mockHostSpec.getUrl()).thenReturn("url");
+    final Set<String> expected = new HashSet<>(Collections.singletonList("url"));
+
+    final HikariPooledConnectionProvider provider = new TestHikariPooledConnectionProvider();
+    try (Connection conn = provider.connect("protocol", mockHostSpec, emptyProperties)) {
+      assertEquals(mockConnection, conn);
+      assertEquals(1, provider.getHostCount());
+      final Set<String> hosts = provider.getHosts();
+      assertEquals(expected, hosts);
+    }
+  }
+
+  @Test
+  void testConnectWithCustomMapping() throws SQLException {
+    when(mockHostSpec.getUrl()).thenReturn("url");
+    final Set<String> expected = new HashSet<>(Collections.singletonList("url+someUniqueKey"));
+
+    final HikariPooledConnectionProvider provider = new TestHikariPooledConnectionProvider(
+        (hostSpec, properties) -> hostSpec.getUrl() + "+someUniqueKey");
+    try (Connection conn = provider.connect("protocol", mockHostSpec, emptyProperties)) {
+      assertEquals(mockConnection, conn);
+      assertEquals(1, provider.getHostCount());
+      final Set<String> hosts = provider.getHosts();
+      assertEquals(expected, hosts);
+    }
+  }
+
+  class TestHikariPooledConnectionProvider extends HikariPooledConnectionProvider {
+
+    public TestHikariPooledConnectionProvider() {
+      super((hostSpec, properties) -> mockConfig, () -> mockDataSource);
+    }
+
+    public TestHikariPooledConnectionProvider(HikariPoolMapping mapping) {
+      super((hostSpec, properties) -> mockConfig, mapping, () -> mockDataSource);
+    }
+
+    @Override
+    String getDataSourceClassName() {
+      return "testHikariPooledConnectionProvider";
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Allow users to specify what key to use for the internal connection pool.

### Description

The connection pool uses the connection URL as the key by default, but users may want to add credentials to the key as well.
User application knows which key best fits their needs, so we should let them decide.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.