### PR TITLE
refactor: fail-fast if the host selection strategy is unsupported

### DIFF
--- a/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/testplugin/BenchmarkPlugin.java
+++ b/benchmarks/src/jmh/java/software/amazon/jdbc/benchmarks/testplugin/BenchmarkPlugin.java
@@ -74,12 +74,15 @@ public class BenchmarkPlugin implements ConnectionPlugin, CanReleaseResources {
   }
 
   @Override
-  public HostSpec getHostSpecByStrategy(HostRole role, String strategy,
-      JdbcCallable<HostSpec, SQLException> getHostSpecByStrategyFunc)
-      throws SQLException {
+  public boolean acceptsStrategy(HostRole role, String strategy) {
+    return false;
+  }
+
+  @Override
+  public HostSpec getHostSpecByStrategy(HostRole role, String strategy) {
     LOGGER.finer(() -> String.format("getHostSpecByStrategy=''%s''", strategy));
     resources.add("getHostSpecByStrategy");
-    return getHostSpecByStrategyFunc.call();
+    return new HostSpec("host", 1234, role);
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionPlugin.java
@@ -56,11 +56,9 @@ public interface ConnectionPlugin {
       final JdbcCallable<Connection, SQLException> forceConnectFunc)
       throws SQLException;
 
-  HostSpec getHostSpecByStrategy(
-      final HostRole role,
-      final String strategy,
-      final JdbcCallable<HostSpec, SQLException> getHostSpecByStrategyFunc)
-      throws SQLException;
+  boolean acceptsStrategy(final HostRole role, final String strategy);
+
+  HostSpec getHostSpecByStrategy(final HostRole role, final String strategy) throws SQLException;
 
   void initHostProvider(
       final String driverProtocol,

--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionProvider.java
@@ -40,8 +40,27 @@ public interface ConnectionProvider {
   boolean acceptsUrl(
       @NonNull String protocol, @NonNull HostSpec hostSpec, @NonNull Properties props);
 
+  /**
+   * Indicates whether the selection strategy is supported by the connection provider.
+   *
+   * @param role Determines if the connection provider should return a reader host or a writer host.
+   * @param strategy The selection strategy to use.
+   * @return whether the strategy is supported.
+   */
   boolean acceptsStrategy(@NonNull HostRole role, @NonNull String strategy);
 
+  /**
+   * Return a reader or a writer node using the specified strategy.
+   * This method should return an {@link UnsupportedOperationException} if the specified strategy is unsupported.
+   *
+   * @param hosts The list of {@link HostSpec} to select from.
+   * @param role Determines if the connection provider should return a writer or a reader.
+   * @param strategy The strategy determining how the {@link HostSpec} should be selected, e.g., random or round-robin.
+   * @return The {@link HostSpec} selected using the specified strategy.
+   *
+   * @throws SQLException if an error occurred while returning the hosts.
+   * @throws UnsupportedOperationException if the strategy is unsupported by the provider.
+   */
   HostSpec getHostSpecByStrategy(@NonNull List<HostSpec> hosts, @NonNull HostRole role,
       @NonNull String strategy) throws SQLException;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionProviderManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionProviderManager.java
@@ -89,6 +89,8 @@ public class ConnectionProviderManager {
         if (connProvider != null && connProvider.acceptsStrategy(role, strategy)) {
           host = connProvider.getHostSpecByStrategy(hosts, role, strategy);
         }
+      } catch (UnsupportedOperationException e) {
+        // The custom provider does not support the provided strategy, ignore it and try with the default provider.
       } finally {
         connProviderLock.readLock().unlock();
       }

--- a/wrapper/src/main/java/software/amazon/jdbc/DataSourceConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/DataSourceConnectionProvider.java
@@ -91,7 +91,9 @@ public class DataSourceConnectionProvider implements ConnectionProvider {
       throws SQLException {
     if (!acceptedStrategies.containsKey(strategy)) {
       throw new UnsupportedOperationException(
-          Messages.get("ConnectionProvider.unsupportedHostSpecSelectorStrategy", new Object[] { strategy }));
+          Messages.get(
+              "ConnectionProvider.unsupportedHostSpecSelectorStrategy",
+              new Object[] {strategy, DataSourceConnectionProvider.class}));
     }
 
     return acceptedStrategies.get(strategy).getHost(hosts, role);

--- a/wrapper/src/main/java/software/amazon/jdbc/DataSourceConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/DataSourceConnectionProvider.java
@@ -90,7 +90,7 @@ public class DataSourceConnectionProvider implements ConnectionProvider {
       @NonNull List<HostSpec> hosts, @NonNull HostRole role, @NonNull String strategy)
       throws SQLException {
     if (!acceptedStrategies.containsKey(strategy)) {
-      throw new SQLException(
+      throw new UnsupportedOperationException(
           Messages.get("ConnectionProvider.unsupportedHostSpecSelectorStrategy", new Object[] { strategy }));
     }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
@@ -77,8 +77,9 @@ public class DriverConnectionProvider implements ConnectionProvider {
       throws SQLException {
     if (!acceptedStrategies.containsKey(strategy)) {
       throw new UnsupportedOperationException(
-          Messages.get("ConnectionProvider.unsupportedHostSpecSelectorStrategy",
-              new Object[] { strategy }));
+          Messages.get(
+              "ConnectionProvider.unsupportedHostSpecSelectorStrategy",
+              new Object[] {strategy, DriverConnectionProvider.class}));
     }
 
     return acceptedStrategies.get(strategy).getHost(hosts, role);

--- a/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
@@ -76,7 +76,7 @@ public class DriverConnectionProvider implements ConnectionProvider {
       @NonNull List<HostSpec> hosts, @NonNull HostRole role, @NonNull String strategy)
       throws SQLException {
     if (!acceptedStrategies.containsKey(strategy)) {
-      throw new SQLException(
+      throw new UnsupportedOperationException(
           Messages.get("ConnectionProvider.unsupportedHostSpecSelectorStrategy",
               new Object[] { strategy }));
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
@@ -48,6 +48,8 @@ public interface PluginService extends ExceptionHandler {
 
   HostSpec getInitialConnectionHostSpec();
 
+  boolean acceptsStrategy(HostRole role, String strategy) throws SQLException;
+
   HostSpec getHostSpecByStrategy(HostRole role, String strategy) throws SQLException;
 
   void setAvailability(Set<String> hostAliases, HostAvailability availability);

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -115,6 +115,11 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   }
 
   @Override
+  public boolean acceptsStrategy(HostRole role, String strategy) throws SQLException {
+    return this.pluginManager.acceptsStrategy(role, strategy);
+  }
+
+  @Override
   public HostSpec getHostSpecByStrategy(HostRole role, String strategy) throws SQLException {
     return this.pluginManager.getHostSpecByStrategy(role, strategy);
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AbstractConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AbstractConnectionPlugin.java
@@ -70,12 +70,13 @@ public abstract class AbstractConnectionPlugin implements ConnectionPlugin {
   }
 
   @Override
-  public HostSpec getHostSpecByStrategy(
-      final HostRole role,
-      final String strategy,
-      final JdbcCallable<HostSpec, SQLException> getHostSpecByStrategyFunc)
-      throws SQLException {
-    return getHostSpecByStrategyFunc.call();
+  public boolean acceptsStrategy(HostRole role, String strategy) {
+    return false;
+  }
+
+  @Override
+  public HostSpec getHostSpecByStrategy(final HostRole role, final String strategy) {
+    return null;
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
@@ -172,15 +172,18 @@ public final class DefaultConnectionPlugin implements ConnectionPlugin {
   }
 
   @Override
-  public HostSpec getHostSpecByStrategy(HostRole role, String strategy,
-      JdbcCallable<HostSpec, SQLException> getHostSpecByStrategyFunc)
+  public boolean acceptsStrategy(HostRole role, String strategy) {
+    return this.connProviderManager.acceptsStrategy(role, strategy);
+  }
+
+  @Override
+  public HostSpec getHostSpecByStrategy(HostRole role, String strategy)
       throws SQLException {
     List<HostSpec> hosts = this.pluginService.getHosts();
     if (hosts.size() < 1) {
       throw new SQLException(Messages.get("DefaultConnectionPlugin.noHostsAvailable"));
     }
 
-    // It's guaranteed that this plugin is always the last in plugin chain so getHostSpecByStrategyFunc can be ignored.
     return this.connProviderManager.getHostSpecByStrategy(hosts, role, strategy);
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -133,7 +133,7 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
 
     if (!pluginService.acceptsStrategy(hostSpec.getRole(), this.readerSelectorStrategy)) {
       throw new UnsupportedOperationException(
-          Messages.get("ConnectionProvider.unsupportedHostSpecSelectorStrategy",
+          Messages.get("ReadWriteSplittingPlugin.unsupportedHostSpecSelectorStrategy",
               new Object[] { this.readerSelectorStrategy }));
     }
     return connectInternal(driverProtocol, hostSpec, isInitialConnection, connectFunc);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -130,6 +130,12 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
       final boolean isInitialConnection,
       final @NonNull JdbcCallable<Connection, SQLException> connectFunc)
       throws SQLException {
+
+    if (!pluginService.acceptsStrategy(hostSpec.getRole(), this.readerSelectorStrategy)) {
+      throw new UnsupportedOperationException(
+          Messages.get("ConnectionProvider.unsupportedHostSpecSelectorStrategy",
+              new Object[] { this.readerSelectorStrategy }));
+    }
     return connectInternal(driverProtocol, hostSpec, isInitialConnection, connectFunc);
   }
 

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -83,7 +83,7 @@ ConnectionPluginManager.unableToLoadPlugin=Unable to load connection plugin fact
 ConnectionPluginManager.methodInvokedAgainstOldConnection=The internal connection has changed since ''{0}'' was created. This is likely due to failover or read-write splitting functionality. To ensure you are using the updated connection, please re-create Statement and ResultSet objects after failover and/or calling setReadOnly.
 
 # Connection Provider
-ConnectionProvider.unsupportedHostSpecSelectorStrategy=getHostSpecByStrategy was called on the ConnectionProvider with an unsupported strategy.
+ConnectionProvider.unsupportedHostSpecSelectorStrategy=Unsupported host selection strategy ''{0}'' specified in readerHostSelectorStrategy. Please visit the documentation for all supported strategies.
 
 # Connection Url Builder
 ConnectionUrlBuilder.missingJdbcProtocol=Missing JDBC protocol and/or host name. Could not construct URL.

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -83,7 +83,7 @@ ConnectionPluginManager.unableToLoadPlugin=Unable to load connection plugin fact
 ConnectionPluginManager.methodInvokedAgainstOldConnection=The internal connection has changed since ''{0}'' was created. This is likely due to failover or read-write splitting functionality. To ensure you are using the updated connection, please re-create Statement and ResultSet objects after failover and/or calling setReadOnly.
 
 # Connection Provider
-ConnectionProvider.unsupportedHostSpecSelectorStrategy=Unsupported host selection strategy ''{0}'' specified in readerHostSelectorStrategy. Please visit the documentation for all supported strategies.
+ConnectionProvider.unsupportedHostSpecSelectorStrategy=Unsupported host selection strategy ''{0}'' specified for this connection provider ''{1}''. Please visit the documentation for all supported strategies.
 
 # Connection Url Builder
 ConnectionUrlBuilder.missingJdbcProtocol=Missing JDBC protocol and/or host name. Could not construct URL.
@@ -204,6 +204,7 @@ ReadWriteSplittingPlugin.executingAgainstOldConnection=Executing method against 
 ReadWriteSplittingPlugin.noReadersAvailable=The plugin was unable to establish a reader connection to any reader instance.
 ReadWriteSplittingPlugin.successfullyConnectedToReader=Successfully connected to a new reader host: ''{0}''
 ReadWriteSplittingPlugin.failedToConnectToReader=Failed to connect to reader host: ''{0}''
+ReadWriteSplittingPlugin.unsupportedHostSpecSelectorStrategy=Unsupported host selection strategy ''{0}'' specified in plugin configuration parameter ''readerHostSelectorStrategy''. Please visit the Read/Write Splitting Plugin documentation for all supported strategies.
 
 # Wrapper Utils
 WrapperUtils.noWrapperClassExists=No wrapper class exists for ''{0}''.

--- a/wrapper/src/test/java/integration/refactored/container/tests/ReadWriteSplittingTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/ReadWriteSplittingTests.java
@@ -438,6 +438,7 @@ public class ReadWriteSplittingTests {
     }
 
     ConnectionProviderManager.releaseResources();
+    ConnectionProviderManager.resetProvider();
   }
 
   @TestTemplate
@@ -469,6 +470,7 @@ public class ReadWriteSplittingTests {
       assertEquals(0, provider.getHostCount(), "Internal connection pool should be empty.");
     }
     ConnectionProviderManager.releaseResources();
+    ConnectionProviderManager.resetProvider();
   }
 
   private static HikariConfig getHikariConfig(HostSpec hostSpec, Properties props) {

--- a/wrapper/src/test/java/software/amazon/jdbc/mock/TestPluginOne.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/mock/TestPluginOne.java
@@ -111,11 +111,14 @@ public class TestPluginOne implements ConnectionPlugin {
   }
 
   @Override
-  public HostSpec getHostSpecByStrategy(HostRole role, String strategy,
-      JdbcCallable<HostSpec, SQLException> getHostSpecByStrategyFunc)
-      throws SQLException {
+  public boolean acceptsStrategy(HostRole role, String strategy) {
+    return false;
+  }
+
+  @Override
+  public HostSpec getHostSpecByStrategy(HostRole role, String strategy) {
     this.calls.add(this.getClass().getSimpleName() + ":before getHostSpecByStrategy");
-    HostSpec result = getHostSpecByStrategyFunc.call();
+    HostSpec result = new HostSpec("host", 1234, role);
     this.calls.add(this.getClass().getSimpleName() + ":after getHostSpecByStrategy");
     return result;
   }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
@@ -286,6 +286,11 @@ public class ConcurrencyTests {
     }
 
     @Override
+    public boolean acceptsStrategy(HostRole role, String strategy) {
+      return false;
+    }
+
+    @Override
     public HostSpec getHostSpecByStrategy(HostRole role, String strategy) throws SQLException {
       return null;
     }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
@@ -126,6 +126,7 @@ public class ReadWriteSplittingPluginTest {
         .thenReturn(mockReaderConn2);
     when(this.mockPluginService.connect(eq(readerHostSpec3), any(Properties.class)))
         .thenReturn(mockReaderConn3);
+    when(this.mockPluginService.acceptsStrategy(any(), eq("random"))).thenReturn(true);
     when(this.mockConnectFunc.call()).thenReturn(mockWriterConn);
     when(mockWriterConn.createStatement()).thenReturn(mockStatement);
     when(mockReaderConn1.createStatement()).thenReturn(mockStatement);


### PR DESCRIPTION
### Summary

The current implementation checks whether the host select strategy is supported right before when we need to use it. We should check it as early as possible.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.