### PR TITLE
[do not merge] suggested fix for auto-detect internal connection pooling

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
@@ -157,4 +157,6 @@ public interface PluginService extends ExceptionHandler {
   void fillAliases(final Connection connection, final HostSpec hostSpec) throws SQLException;
 
   ConnectionProvider getConnectionProvider();
+
+  String getDriverProtocol();
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
@@ -155,4 +155,6 @@ public interface PluginService extends ExceptionHandler {
   HostSpec identifyConnection(final Connection connection) throws SQLException;
 
   void fillAliases(final Connection connection, final HostSpec hostSpec) throws SQLException;
+
+  ConnectionProvider getConnectionProvider();
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -66,6 +66,11 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   protected final DialectProvider dialectProvider;
   protected Dialect dialect;
 
+  @Override
+  public ConnectionProvider getConnectionProvider() {
+    return this.pluginManager.defaultConnProvider;
+  }
+
   public PluginServiceImpl(
       @NonNull final ConnectionPluginManager pluginManager,
       @NonNull final Properties props,

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -66,11 +66,6 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   protected final DialectProvider dialectProvider;
   protected Dialect dialect;
 
-  @Override
-  public ConnectionProvider getConnectionProvider() {
-    return this.pluginManager.defaultConnProvider;
-  }
-
   public PluginServiceImpl(
       @NonNull final ConnectionPluginManager pluginManager,
       @NonNull final Properties props,
@@ -154,6 +149,16 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
       }
     }
     return null;
+  }
+
+  @Override
+  public ConnectionProvider getConnectionProvider() {
+    return this.pluginManager.defaultConnProvider;
+  }
+
+  @Override
+  public String getDriverProtocol() {
+    return this.driverProtocol;
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -255,10 +255,11 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
 
   private void getNewWriterConnection(final HostSpec writerHostSpec) throws SQLException {
     final Connection conn = this.pluginService.connect(writerHostSpec, this.properties);
-    final String driverProtocol = conn.getMetaData().getURL().split("//", 2)[0];
-    this.isWriterConnFromInternalPool =
-        this.connProviderManager.getConnectionProvider(driverProtocol, writerHostSpec, this.properties)
-            instanceof PooledConnectionProvider;
+    this.isWriterConnFromInternalPool = this.connProviderManager.getConnectionProvider(
+        this.pluginService.getDriverProtocol(),
+        writerHostSpec,
+        this.properties)
+        instanceof PooledConnectionProvider;
     setWriterConnection(conn, writerHostSpec);
     switchCurrentConnectionTo(this.writerConnection, writerHostSpec);
   }
@@ -498,10 +499,11 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
       HostSpec hostSpec = this.pluginService.getHostSpecByStrategy(HostRole.READER, this.readerSelectorStrategy);
       try {
         conn = this.pluginService.connect(hostSpec, this.properties);
-        final String driverProtocol = conn.getMetaData().getURL().split("//", 2)[0];
-        this.isReaderConnFromInternalPool =
-            this.connProviderManager.getConnectionProvider(driverProtocol, hostSpec, this.properties)
-                instanceof PooledConnectionProvider;
+        this.isReaderConnFromInternalPool = this.connProviderManager.getConnectionProvider(
+            this.pluginService.getDriverProtocol(),
+            hostSpec,
+            this.properties)
+            instanceof PooledConnectionProvider;
         readerHost = hostSpec;
         break;
       } catch (final SQLException e) {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -55,9 +55,11 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
           add("connect");
           add("notifyConnectionChanged");
           add("Connection.setReadOnly");
+          add("Connection.clearWarnings");
         }
       });
   static final String METHOD_SET_READ_ONLY = "Connection.setReadOnly";
+  static final String METHOD_CLEAR_WARNINGS = "Connection.clearWarnings";
 
   private final PluginService pluginService;
   private final Properties properties;
@@ -209,6 +211,19 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
     if (methodName.equals(METHOD_SET_READ_ONLY) && args != null && args.length > 0) {
       try {
         switchConnectionIfRequired((Boolean) args[0]);
+      } catch (final SQLException e) {
+        throw WrapperUtils.wrapExceptionIfNeeded(exceptionClass, e);
+      }
+    }
+
+    if (methodName.equals(METHOD_CLEAR_WARNINGS)) {
+      try {
+        if (this.writerConnection != null && !this.writerConnection.isClosed()) {
+          this.writerConnection.clearWarnings();
+        }
+        if (this.readerConnection != null && !this.readerConnection.isClosed()) {
+          this.readerConnection.clearWarnings();
+        }
       } catch (final SQLException e) {
         throw WrapperUtils.wrapExceptionIfNeeded(exceptionClass, e);
       }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
@@ -400,6 +400,11 @@ public class ConcurrencyTests {
     public ConnectionProvider getConnectionProvider() {
       return null;
     }
+
+    @Override
+    public String getDriverProtocol() {
+      return null;
+    }
   }
 
   public static class TestConnection implements Connection {

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
@@ -57,6 +57,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.jdbc.ConnectionPlugin;
+import software.amazon.jdbc.ConnectionProvider;
 import software.amazon.jdbc.HostAvailability;
 import software.amazon.jdbc.HostListProvider;
 import software.amazon.jdbc.HostRole;
@@ -309,7 +310,6 @@ public class ConcurrencyTests {
 
     @Override
     public void setAvailability(Set<String> hostAliases, HostAvailability availability) {
-
     }
 
     @Override
@@ -394,6 +394,11 @@ public class ConcurrencyTests {
     @Override
     public void fillAliases(Connection connection, HostSpec hostSpec) throws SQLException {
 
+    }
+
+    @Override
+    public ConnectionProvider getConnectionProvider() {
+      return null;
     }
   }
 

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -97,7 +96,6 @@ public class ReadWriteSplittingPluginTest {
   @Mock private Statement mockStatement;
   @Mock private ResultSet mockResultSet;
   @Mock private EnumSet<NodeChangeOptions> mockChanges;
-  @Mock private DatabaseMetaData mockDatabaseMetaData;
 
   @BeforeEach
   public void init() throws SQLException {
@@ -137,11 +135,6 @@ public class ReadWriteSplittingPluginTest {
     when(mockStatement.executeQuery(any(String.class))).thenReturn(mockResultSet);
     when(mockResultSet.next()).thenReturn(true);
     when(mockClosedWriterConn.isClosed()).thenReturn(true);
-    when(mockReaderConn1.getMetaData()).thenReturn(mockDatabaseMetaData);
-    when(mockReaderConn2.getMetaData()).thenReturn(mockDatabaseMetaData);
-    when(mockReaderConn3.getMetaData()).thenReturn(mockDatabaseMetaData);
-    when(mockWriterConn.getMetaData()).thenReturn(mockDatabaseMetaData);
-    when(mockDatabaseMetaData.getURL()).thenReturn("jdbc:postgresql://testUrl");
   }
 
   @Test

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
@@ -21,13 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -97,6 +97,7 @@ public class ReadWriteSplittingPluginTest {
   @Mock private Statement mockStatement;
   @Mock private ResultSet mockResultSet;
   @Mock private EnumSet<NodeChangeOptions> mockChanges;
+  @Mock private DatabaseMetaData mockDatabaseMetaData;
 
   @BeforeEach
   public void init() throws SQLException {
@@ -136,6 +137,11 @@ public class ReadWriteSplittingPluginTest {
     when(mockStatement.executeQuery(any(String.class))).thenReturn(mockResultSet);
     when(mockResultSet.next()).thenReturn(true);
     when(mockClosedWriterConn.isClosed()).thenReturn(true);
+    when(mockReaderConn1.getMetaData()).thenReturn(mockDatabaseMetaData);
+    when(mockReaderConn2.getMetaData()).thenReturn(mockDatabaseMetaData);
+    when(mockReaderConn3.getMetaData()).thenReturn(mockDatabaseMetaData);
+    when(mockWriterConn.getMetaData()).thenReturn(mockDatabaseMetaData);
+    when(mockDatabaseMetaData.getURL()).thenReturn("jdbc:postgresql://testUrl");
   }
 
   @Test


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

### Description

This will be the suggested to be added to a customer PR (548), to close reader connections after switching to read-write only when internal connection pooling is used.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.